### PR TITLE
Enable offspring to inherit food restriction from mother

### DIFF
--- a/Source/FoodRestrictions.csproj
+++ b/Source/FoodRestrictions.csproj
@@ -41,6 +41,7 @@
     <None Include="release.targets" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Patch\RimWorld_PawnUtility_TrySpawnHatchedOrBornPawn.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Mod.cs" />
     <Compile Include="Patch\RimWorld_Pawn_FoodRestrictionTracker_Configurable.cs" />

--- a/Source/Patch/RimWorld_PawnUtility_TrySpawnHatchedOrBornPawn.cs
+++ b/Source/Patch/RimWorld_PawnUtility_TrySpawnHatchedOrBornPawn.cs
@@ -1,0 +1,40 @@
+﻿using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace FoodRestrictions.Patch
+{
+    [HarmonyPatch(typeof(PawnUtility), nameof(PawnUtility.TrySpawnHatchedOrBornPawn))]
+    internal static class RimWorld_PawnUtility_TrySpawnHatchedOrBornPawn
+    {
+        
+        private static void Postfix(Pawn pawn,
+            Thing motherOrEgg,
+            IntVec3? positionOverride = null)
+        {
+            // if TrySpawnHatchedOrBornPawn is called by mammal animal then motherOrEgg is <Pawn mother>
+            // if TrySpawnHatchedOrBornPawn is called by hatched egg then motherOrEgg is <ThingWithComps egg>
+            // if TrySpawnHatchedOrBornPawn is called by humanlike then.. it could be several <Thing>s - we don't care
+            if (pawn.RaceProps.Humanlike ||
+                ((!pawn.Faction?.IsPlayer ?? true) && (!pawn.HostFaction?.IsPlayer ?? true)))
+                return;
+
+            switch (motherOrEgg)
+            {
+                case Pawn mother when mother.foodRestriction != null:
+                    pawn.foodRestriction.CurrentFoodRestriction = mother.foodRestriction.CurrentFoodRestriction;
+                    break;
+                case ThingWithComps egg:
+                {
+                    var compHatcher = egg.TryGetComp<CompHatcher>();
+                    if (compHatcher?.hatcheeParent.foodRestriction != null)
+                    {
+                        pawn.foodRestriction.CurrentFoodRestriction = compHatcher.hatcheeParent.foodRestriction.CurrentFoodRestriction;    
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
With this update the offspring is able to inherit the food restrictions of the mother.

Tested with egg-laying creature and mammals.

You can include this in your next update. I have not updated version information for 1.4 compatbility.

If you don't want to invest time here anymore I would be thankful if you could add a LICENSE file so that someone can continue your work. I am using MIT License for all my modding works.

I have also created a mass-assign food restriction UI for Numbers mod that works like the area-assign column that I will contribute there later.